### PR TITLE
docs: Fix Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ new LoggerConfiguration()
                 // etc etc
             };
         });
-```csharp
+```
 
 It is also possible to not use any masking operators but instead mask based on property names. In that case you can configure the enricher to not use any masking operators at all:
 
@@ -130,7 +130,7 @@ new LoggerConfiguration()
         {
             options.MaskingOperators.Clear();
         });
-```csharp
+```
 
 ### Using a custom mask value
 


### PR DESCRIPTION
Small syntax issue—language tag is attached to the beginning and end of a few fenced code blocks, which breaks the rendering of what is supposed to be prose:

<img width="670" alt="Screen Shot 2023-01-06 at 12 57 53 PM" src="https://user-images.githubusercontent.com/13277/210940176-bab95d35-0913-4847-a7d4-2f8516053519.png">
