### PR TITLE
added mask for uri as scalar value

### DIFF
--- a/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
+++ b/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
@@ -130,6 +130,17 @@ namespace Serilog.Enrichers.Sensitive
                         }
 
                         return (false, null);
+                    }    
+                case ScalarValue { Value: Uri uriValue }: // обработки этого случая нет в исходной библиотеке
+                    {
+                        var (wasMasked, maskedValue) = ReplaceSensitiveDataFromString(uriValue.ToString(C));
+
+                        if (wasMasked)
+                        {
+                            return (true, new ScalarValue(maskedValue));
+                        }
+
+                        return (false, null);
                     }
                 case SequenceValue sequenceValue:
                     var resultElements = new List<LogEventPropertyValue>();

--- a/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
+++ b/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
@@ -131,7 +131,7 @@ namespace Serilog.Enrichers.Sensitive
 
                         return (false, null);
                     }    
-                case ScalarValue { Value: Uri uriValue }: // обработки этого случая нет в исходной библиотеке
+                case ScalarValue { Value: Uri uriValue }:
                     {
                         var (wasMasked, maskedValue) = ReplaceSensitiveDataFromString(uriValue.ToString(C));
 

--- a/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
+++ b/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
@@ -133,7 +133,7 @@ namespace Serilog.Enrichers.Sensitive
                     }    
                 case ScalarValue { Value: Uri uriValue }:
                     {
-                        var (wasMasked, maskedValue) = ReplaceSensitiveDataFromString(uriValue.ToString(C));
+                        var (wasMasked, maskedValue) = ReplaceSensitiveDataFromString(uriValue.ToString());
 
                         if (wasMasked)
                         {


### PR DESCRIPTION
Hi! 
I've faced problems when Uri pushed in log as param and it wasn't masked.
I added an additional case section to handle that.