### PR TITLE
Support masking properties that have a Uri as the value

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for Serilog.Enrichers.Sensitive
 
+## 1.7.3
+
+- Add support for masking property values that contain a `Uri`, reported by @yadanilov19
+
 ## 1.7.2
 
 - FIx issue where Microsoft.Extensions.Configuration.Binder version 7.0.0 or up was required for JSON configuration to work. [#25](https://github.com/serilog-contrib/Serilog.Enrichers.Sensitive/issues/25)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.7.2.0</Version>
+		<Version>1.7.3.0</Version>
 		<Authors>Sander van Vliet, Huibert Jan Nieuwkamer, Scott Toberman</Authors>
 		<Company>Codenizer BV</Company>
 		<Copyright>2023 Sander van Vliet</Copyright>

--- a/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
+++ b/src/Serilog.Enrichers.Sensitive/SensitiveDataEnricher.cs
@@ -131,6 +131,21 @@ namespace Serilog.Enrichers.Sensitive
 
                         return (false, null);
                     }
+                // System.Uri is a built-in scalar type in Serilog:
+                // https://github.com/serilog/serilog/blob/dev/src/Serilog/Capturing/PropertyValueConverter.cs#L23
+                // which is why this needs special handling and isn't
+                // caught by the string value above.
+                case ScalarValue { Value: Uri uriValue }:
+                {
+                    var (wasMasked, maskedValue) = ReplaceSensitiveDataFromString(uriValue.ToString());
+
+                    if (wasMasked)
+                    {
+                        return (true, new ScalarValue(new Uri(maskedValue)));
+                    }
+
+                    return (false, null);
+                }
                 case SequenceValue sequenceValue:
                     var resultElements = new List<LogEventPropertyValue>();
                     var anyElementMasked = false;

--- a/test/Serilog.Enrichers.Sensitive.Tests.Unit/WhenMaskingLogEventWithNonStringScalarValue.cs
+++ b/test/Serilog.Enrichers.Sensitive.Tests.Unit/WhenMaskingLogEventWithNonStringScalarValue.cs
@@ -1,0 +1,96 @@
+﻿using Serilog.Core;
+using Serilog.Sinks.InMemory;
+using System;
+using System.Text.RegularExpressions;
+using Serilog.Sinks.InMemory.Assertions;
+using Xunit;
+
+namespace Serilog.Enrichers.Sensitive.Tests.Unit
+{
+    public class WhenMaskingLogEventWithNonStringScalarValue
+    {
+        private readonly InMemorySink _inMemorySnk;
+        private readonly Logger _logger;
+
+        [Fact]
+        public void GivenPropertyValueIsUri_ValueIsMasked()
+        {
+            _logger.Information("Message {Prop}", new Uri("https://tempuri.org?someparam=SENSITIVE"));
+
+            _inMemorySnk
+                .Snapshot()
+                .Should()
+                .HaveMessage("Message {Prop}")
+                .Appearing()
+                .Once()
+                .WithProperty("Prop")
+                .WithValue(new Uri("https://tempuri.org?***MASKED***"));
+        }
+
+        [Fact]
+        public void GivenPropertyValueIsTypeWithToStringOverride_ValueIsMasked()
+        {
+            _logger.Information("Message {Prop}", new TypeWithToStringOverride("my SECRET message"));
+
+            _inMemorySnk
+                .Snapshot()
+                .Should()
+                .HaveMessage("Message {Prop}")
+                .Appearing()
+                .Once()
+                .WithProperty("Prop")
+                .WithValue("my ***MASKED*** message");
+        }
+
+        public WhenMaskingLogEventWithNonStringScalarValue()
+        {
+            _inMemorySnk = new InMemorySink();
+
+            _logger = new LoggerConfiguration()
+                .Enrich.WithSensitiveDataMasking(options =>
+                {
+                    options.MaskingOperators.Add(new UriMaskingOperator());
+                    options.MaskingOperators.Add(new TestRegexMaskingOperator());
+                })
+                .WriteTo.Sink(_inMemorySnk)
+                .CreateLogger();
+        }
+    }
+
+    public class TestRegexMaskingOperator : RegexMaskingOperator
+    {
+        public TestRegexMaskingOperator() : base("SECRET", RegexOptions.Compiled)
+        {
+        }
+    }
+
+    public class TypeWithToStringOverride
+    {
+        private readonly string _value;
+
+        public TypeWithToStringOverride(string value)
+        {
+            _value = value;
+        }
+
+        public override string ToString()
+        {
+            return _value;
+        }
+    }
+
+    public class UriMaskingOperator : RegexMaskingOperator
+    {
+        private const string SomePattern =
+            "someparam=.*?(.(?:&|$))";
+
+        public UriMaskingOperator() : base(SomePattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)
+        {
+        }
+
+        protected override string PreprocessInput(string input)
+        {
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
Reported in #31 by @yadanilov19 

This PR adds support for masking log messages that have a property which is a `Uri` instance.

Serilog treats `Uri` as a built-in type which means it's not automatically covered by the automatic string conversion for other property value types.